### PR TITLE
Linux version of the copydir plugin

### DIFF
--- a/plugins/copydir/copydir.plugin.zsh
+++ b/plugins/copydir/copydir.plugin.zsh
@@ -1,3 +1,3 @@
 function copydir {
-  pwd | tr -d "\r\n" | pbcopy
+  pwd | tr -d "\r\n" | xsel --clipboard --input
 }


### PR DESCRIPTION
I updated copydir plugin for linux user.
With arch, xsel is needed:
sudo pacman -S xsel
The plugin works fine to me.